### PR TITLE
Add projection catch-up support with configurable batch size

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: crystal-es
-version: 0.4.1
+version: 0.5.0
 
 authors:
   - Tristan Holl <mail@tristanholl.com>

--- a/spec/components/projection_spec.cr
+++ b/spec/components/projection_spec.cr
@@ -1,5 +1,44 @@
 require "../spec_helper"
 
+class TestProjectIfEmptyProjection < ES::Projection
+  @@project_if_empty = true
+  @@projection_batch_size = 1_i64
+  getter collected : Array(UUID) = [] of UUID
+
+  protected def table_empty? : Bool
+    true
+  end
+
+  protected def apply(event : ES::Event)
+    @collected << event.header.event_id
+  end
+end
+
+class TestProjectNotEmptyProjection < ES::Projection
+  @@project_if_empty = true
+  getter collected : Array(UUID) = [] of UUID
+
+  protected def table_empty? : Bool
+    false
+  end
+
+  protected def apply(event : ES::Event)
+    @collected << event.header.event_id
+  end
+end
+
+class TestProjectIfEmptyDisabledProjection < ES::Projection
+  getter collected : Array(UUID) = [] of UUID
+
+  protected def table_empty? : Bool
+    true
+  end
+
+  protected def apply(event : ES::Event)
+    @collected << event.header.event_id
+  end
+end
+
 class TestProjection < ES::Projection
   getter collected : Array(UUID) = [] of UUID
 
@@ -102,6 +141,81 @@ describe ES::Projection do
       projection = TestProjection.new(event_handlers: handlers, event_store: store, projection_database: db)
       projection.replay(truncate: false)
     end
+  end
+end
+
+describe "ES::Projection#project_if_empty" do
+  it "replays all events in the store when table is empty and project_if_empty? is true" do
+    store = ES::EventStoreAdapters::InMemory.new
+    handlers = ES::EventHandlers.new
+    handlers.register(DummyEvent)
+    db = DBMock.open
+
+    e1 = DummyEvent.new
+    e2 = DummyEvent.new
+    store.append(e1)
+    store.append(e2)
+
+    projection = TestProjectIfEmptyProjection.new(event_handlers: handlers, event_store: store, projection_database: db)
+    projection.project_if_empty
+    Fiber.yield
+
+    projection.collected.should eq([e1.header.event_id, e2.header.event_id])
+  end
+
+  it "does not replay when table is not empty" do
+    store = ES::EventStoreAdapters::InMemory.new
+    handlers = ES::EventHandlers.new
+    handlers.register(DummyEvent)
+    db = DBMock.open
+
+    store.append(DummyEvent.new)
+
+    projection = TestProjectNotEmptyProjection.new(event_handlers: handlers, event_store: store, projection_database: db)
+    projection.project_if_empty
+    Fiber.yield
+
+    projection.collected.should be_empty
+  end
+
+  it "does not replay when project_if_empty? is false" do
+    store = ES::EventStoreAdapters::InMemory.new
+    handlers = ES::EventHandlers.new
+    handlers.register(DummyEvent)
+    db = DBMock.open
+
+    store.append(DummyEvent.new)
+
+    projection = TestProjectIfEmptyDisabledProjection.new(event_handlers: handlers, event_store: store, projection_database: db)
+    projection.project_if_empty
+    Fiber.yield
+
+    projection.collected.should be_empty
+  end
+
+  it "skips unregistered event handles during catch-up" do
+    store = ES::EventStoreAdapters::InMemory.new
+    handlers = ES::EventHandlers.new
+    # DummyEvent not registered
+    db = DBMock.open
+
+    store.append(DummyEvent.new)
+
+    projection = TestProjectIfEmptyProjection.new(event_handlers: handlers, event_store: store, projection_database: db)
+    projection.project_if_empty
+    Fiber.yield
+
+    projection.collected.should be_empty
+  end
+end
+
+describe "ES::Projection.projection_batch_size" do
+  it "defaults to 1000" do
+    TestProjection.projection_batch_size.should eq(1000_i64)
+  end
+
+  it "reflects the configured value" do
+    TestProjectIfEmptyProjection.projection_batch_size.should eq(1_i64)
   end
 end
 

--- a/spec/components/projection_spec.cr
+++ b/spec/components/projection_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 class TestProjectIfEmptyProjection < ES::Projection
-  @@project_if_empty = true
+  @@init = true
   @@projection_batch_size = 1_i64
   getter collected : Array(UUID) = [] of UUID
 
@@ -15,7 +15,7 @@ class TestProjectIfEmptyProjection < ES::Projection
 end
 
 class TestProjectNotEmptyProjection < ES::Projection
-  @@project_if_empty = true
+  @@init = true
   getter collected : Array(UUID) = [] of UUID
 
   protected def table_empty? : Bool
@@ -144,8 +144,8 @@ describe ES::Projection do
   end
 end
 
-describe "ES::Projection#project_if_empty" do
-  it "replays all events in the store when table is empty and project_if_empty? is true" do
+describe "ES::Projection#init" do
+  it "replays all events in the store when table is empty and init? is true" do
     store = ES::EventStoreAdapters::InMemory.new
     handlers = ES::EventHandlers.new
     handlers.register(DummyEvent)
@@ -157,7 +157,7 @@ describe "ES::Projection#project_if_empty" do
     store.append(e2)
 
     projection = TestProjectIfEmptyProjection.new(event_handlers: handlers, event_store: store, projection_database: db)
-    projection.project_if_empty
+    projection.init
     Fiber.yield
 
     projection.collected.should eq([e1.header.event_id, e2.header.event_id])
@@ -172,13 +172,13 @@ describe "ES::Projection#project_if_empty" do
     store.append(DummyEvent.new)
 
     projection = TestProjectNotEmptyProjection.new(event_handlers: handlers, event_store: store, projection_database: db)
-    projection.project_if_empty
+    projection.init
     Fiber.yield
 
     projection.collected.should be_empty
   end
 
-  it "does not replay when project_if_empty? is false" do
+  it "does not replay when init? is false" do
     store = ES::EventStoreAdapters::InMemory.new
     handlers = ES::EventHandlers.new
     handlers.register(DummyEvent)
@@ -187,7 +187,7 @@ describe "ES::Projection#project_if_empty" do
     store.append(DummyEvent.new)
 
     projection = TestProjectIfEmptyDisabledProjection.new(event_handlers: handlers, event_store: store, projection_database: db)
-    projection.project_if_empty
+    projection.init
     Fiber.yield
 
     projection.collected.should be_empty
@@ -202,7 +202,7 @@ describe "ES::Projection#project_if_empty" do
     store.append(DummyEvent.new)
 
     projection = TestProjectIfEmptyProjection.new(event_handlers: handlers, event_store: store, projection_database: db)
-    projection.project_if_empty
+    projection.init
     Fiber.yield
 
     projection.collected.should be_empty

--- a/src/components/projection.cr
+++ b/src/components/projection.cr
@@ -1,7 +1,7 @@
 module ES
   abstract class Projection
     @@table = ""
-    @@project_if_empty : Bool = false
+    @@init : Bool = false
     @@projection_batch_size : Int64 = 1000_i64
 
     @event_handlers : ES::EventHandlers
@@ -28,8 +28,8 @@ module ES
       @@table
     end
 
-    def self.project_if_empty? : Bool
-      @@project_if_empty
+    def self.init? : Bool
+      @@init
     end
 
     def self.projection_batch_size : Int64
@@ -54,10 +54,10 @@ module ES
       end
     end
 
-    # If project_if_empty? is set and the projection table is empty, consume all
-    # events from the store in a background fiber until the projection is up to date.
-    def project_if_empty
-      return unless self.class.project_if_empty?
+    # If init? is set and the projection table is empty, consume all events from
+    # the store in a background fiber until the projection is up to date.
+    def init
+      return unless self.class.init?
       return unless table_empty?
 
       spawn do

--- a/src/components/projection.cr
+++ b/src/components/projection.cr
@@ -1,7 +1,8 @@
-# TODO: Implement projector
 module ES
   abstract class Projection
     @@table = ""
+    @@project_if_empty : Bool = false
+    @@projection_batch_size : Int64 = 1000_i64
 
     @event_handlers : ES::EventHandlers
     @event_store : ES::EventStore
@@ -23,9 +24,16 @@ module ES
     )
     end
 
-    # Returns the projection table name
     def self.table
       @@table
+    end
+
+    def self.project_if_empty? : Bool
+      @@project_if_empty
+    end
+
+    def self.projection_batch_size : Int64
+      @@projection_batch_size
     end
 
     def call(event : ES::Event)
@@ -44,6 +52,29 @@ module ES
         h = ES::Event::Header.from_json(es_event.header.to_json)
         call(@event_handlers.event_class(handle).new(h, es_event.body))
       end
+    end
+
+    # If project_if_empty? is set and the projection table is empty, consume all
+    # events from the store in a background fiber until the projection is up to date.
+    def project_if_empty
+      return unless self.class.project_if_empty?
+      return unless table_empty?
+
+      spawn do
+        @event_store.each_event(batch_size: self.class.projection_batch_size) do |es_event|
+          handle = es_event.header["event_handle"].as_s
+          next unless @event_handlers.registered?(handle)
+
+          h = ES::Event::Header.from_json(es_event.header.to_json)
+          call(@event_handlers.event_class(handle).new(h, es_event.body))
+        end
+      end
+    end
+
+    protected def table_empty? : Bool
+      t = self.class.table
+      return false if t.empty?
+      @projection_database.query_one("SELECT NOT EXISTS (SELECT 1 FROM #{t} LIMIT 1)", as: Bool)
     end
 
     # Truncate the projection table and optionally restart the identity sequence

--- a/src/components/projection_dsl.cr
+++ b/src/components/projection_dsl.cr
@@ -17,13 +17,13 @@ module ES
       end
     end
 
-    macro define_projection(table, project_if_empty = false, batch_size = 1000_i64)
+    macro define_projection(table, init = false, batch_size = 1000_i64)
       {% raise "define_projection requires at least one column declaration; add a block with `column` calls" %}
     end
 
-    macro define_projection(table, project_if_empty = false, batch_size = 1000_i64, &block)
+    macro define_projection(table, init = false, batch_size = 1000_i64, &block)
       @@table = {{table}}
-      @@project_if_empty = {{project_if_empty}}
+      @@init = {{init}}
       @@projection_batch_size = {{batch_size}}.to_i64
 
       {%
@@ -108,7 +108,7 @@ module ES
           {% end %}
         end
 
-        project_if_empty
+        init
       end
 
       def setup

--- a/src/components/projection_dsl.cr
+++ b/src/components/projection_dsl.cr
@@ -17,12 +17,14 @@ module ES
       end
     end
 
-    macro define_projection(table)
+    macro define_projection(table, project_if_empty = false, batch_size = 1000_i64)
       {% raise "define_projection requires at least one column declaration; add a block with `column` calls" %}
     end
 
-    macro define_projection(table, &block)
+    macro define_projection(table, project_if_empty = false, batch_size = 1000_i64, &block)
       @@table = {{table}}
+      @@project_if_empty = {{project_if_empty}}
+      @@projection_batch_size = {{batch_size}}.to_i64
 
       {%
         parts = table.split(".")
@@ -46,64 +48,67 @@ module ES
           %(SELECT EXISTS (SELECT FROM pg_tables WHERE schemaname = '{{schema_name.id}}' AND tablename = '{{table_name.id}}')),
           as: Bool
         )
-        return if skip
 
-        @projection_database.exec %(
-          CREATE TABLE "{{schema_name.id}}"."{{table_name.id}}" (
-            {% for col_def, col_i in cols %}
-              {% col_name = col_def.args[0].id %}
-              {% col_type_str = col_def.args[1].stringify %}
-              {% is_primary = false %}
-              {% is_serial = false %}
-              {% is_bigserial = false %}
-              {% is_null = false %}
-              {% has_default = false %}
-              {% default_val = nil %}
-              {% for col_opt in col_def.named_args %}
-                {% if col_opt.name.stringify == "primary_key" %}{% is_primary = col_opt.value %}{% end %}
-                {% if col_opt.name.stringify == "serial" %}{% is_serial = col_opt.value %}{% end %}
-                {% if col_opt.name.stringify == "bigserial" %}{% is_bigserial = col_opt.value %}{% end %}
-                {% if col_opt.name.stringify == "null" %}{% is_null = col_opt.value %}{% end %}
-                {% if col_opt.name.stringify == "default" %}{% has_default = true %}{% default_val = col_opt.value %}{% end %}
+        unless skip
+          @projection_database.exec %(
+            CREATE TABLE "{{schema_name.id}}"."{{table_name.id}}" (
+              {% for col_def, col_i in cols %}
+                {% col_name = col_def.args[0].id %}
+                {% col_type_str = col_def.args[1].stringify %}
+                {% is_primary = false %}
+                {% is_serial = false %}
+                {% is_bigserial = false %}
+                {% is_null = false %}
+                {% has_default = false %}
+                {% default_val = nil %}
+                {% for col_opt in col_def.named_args %}
+                  {% if col_opt.name.stringify == "primary_key" %}{% is_primary = col_opt.value %}{% end %}
+                  {% if col_opt.name.stringify == "serial" %}{% is_serial = col_opt.value %}{% end %}
+                  {% if col_opt.name.stringify == "bigserial" %}{% is_bigserial = col_opt.value %}{% end %}
+                  {% if col_opt.name.stringify == "null" %}{% is_null = col_opt.value %}{% end %}
+                  {% if col_opt.name.stringify == "default" %}{% has_default = true %}{% default_val = col_opt.value %}{% end %}
+                {% end %}
+                {% if is_serial %}
+                  {% sql_type = "SERIAL" %}
+                {% elsif is_bigserial %}
+                  {% sql_type = "BIGSERIAL" %}
+                {% elsif col_type_str == "String" %}
+                  {% sql_type = "TEXT" %}
+                {% elsif col_type_str == "Int32" %}
+                  {% sql_type = "INTEGER" %}
+                {% elsif col_type_str == "Int64" %}
+                  {% sql_type = "BIGINT" %}
+                {% elsif col_type_str == "Float64" %}
+                  {% sql_type = "DOUBLE PRECISION" %}
+                {% elsif col_type_str == "Bool" %}
+                  {% sql_type = "BOOLEAN" %}
+                {% elsif col_type_str == "UUID" %}
+                  {% sql_type = "UUID" %}
+                {% elsif col_type_str == "Time" %}
+                  {% sql_type = "TIMESTAMPTZ" %}
+                {% elsif col_type_str == "JSON::Any" %}
+                  {% sql_type = "JSONB" %}
+                {% else %}
+                  {% sql_type = "TEXT" %}
+                {% end %}
+                "{{col_name}}" {{sql_type.id}} {% if is_primary %}PRIMARY KEY{% elsif is_null %}NULL{% else %}NOT NULL{% end %}{% if has_default %} DEFAULT {% if default_val.is_a?(StringLiteral) %}'{{default_val.id}}'{% else %}{{default_val}}{% end %}{% end %}{% if col_i < cols.size - 1 %},{% end %}
               {% end %}
-              {% if is_serial %}
-                {% sql_type = "SERIAL" %}
-              {% elsif is_bigserial %}
-                {% sql_type = "BIGSERIAL" %}
-              {% elsif col_type_str == "String" %}
-                {% sql_type = "TEXT" %}
-              {% elsif col_type_str == "Int32" %}
-                {% sql_type = "INTEGER" %}
-              {% elsif col_type_str == "Int64" %}
-                {% sql_type = "BIGINT" %}
-              {% elsif col_type_str == "Float64" %}
-                {% sql_type = "DOUBLE PRECISION" %}
-              {% elsif col_type_str == "Bool" %}
-                {% sql_type = "BOOLEAN" %}
-              {% elsif col_type_str == "UUID" %}
-                {% sql_type = "UUID" %}
-              {% elsif col_type_str == "Time" %}
-                {% sql_type = "TIMESTAMPTZ" %}
-              {% elsif col_type_str == "JSON::Any" %}
-                {% sql_type = "JSONB" %}
-              {% else %}
-                {% sql_type = "TEXT" %}
-              {% end %}
-              "{{col_name}}" {{sql_type.id}} {% if is_primary %}PRIMARY KEY{% elsif is_null %}NULL{% else %}NOT NULL{% end %}{% if has_default %} DEFAULT {% if default_val.is_a?(StringLiteral) %}'{{default_val.id}}'{% else %}{{default_val}}{% end %}{% end %}{% if col_i < cols.size - 1 %},{% end %}
-            {% end %}
+            )
           )
-        )
 
-        {% for idx_def in idxs %}
-          {% idx_cols = idx_def.args[0] %}
-          {% is_unique = false %}
-          {% idx_name = nil %}
-          {% for idx_opt in idx_def.named_args %}
-            {% if idx_opt.name.stringify == "unique" %}{% is_unique = idx_opt.value %}{% end %}
-            {% if idx_opt.name.stringify == "name" %}{% idx_name = idx_opt.value %}{% end %}
+          {% for idx_def in idxs %}
+            {% idx_cols = idx_def.args[0] %}
+            {% is_unique = false %}
+            {% idx_name = nil %}
+            {% for idx_opt in idx_def.named_args %}
+              {% if idx_opt.name.stringify == "unique" %}{% is_unique = idx_opt.value %}{% end %}
+              {% if idx_opt.name.stringify == "name" %}{% idx_name = idx_opt.value %}{% end %}
+            {% end %}
+            @projection_database.exec %(CREATE{% if is_unique %} UNIQUE{% end %} INDEX {% if idx_name %}{{idx_name.id}}{% else %}{{table_name.id}}_{% for idx_col, idx_ci in idx_cols %}{{idx_col.id}}{% if idx_ci < idx_cols.size - 1 %}_{% end %}{% end %}_idx{% end %} ON "{{schema_name.id}}"."{{table_name.id}}"({% for idx_col, idx_ci in idx_cols %}{{idx_col.id}}{% if idx_ci < idx_cols.size - 1 %}, {% end %}{% end %}))
           {% end %}
-          @projection_database.exec %(CREATE{% if is_unique %} UNIQUE{% end %} INDEX {% if idx_name %}{{idx_name.id}}{% else %}{{table_name.id}}_{% for idx_col, idx_ci in idx_cols %}{{idx_col.id}}{% if idx_ci < idx_cols.size - 1 %}_{% end %}{% end %}_idx{% end %} ON "{{schema_name.id}}"."{{table_name.id}}"({% for idx_col, idx_ci in idx_cols %}{{idx_col.id}}{% if idx_ci < idx_cols.size - 1 %}, {% end %}{% end %}))
-        {% end %}
+        end
+
+        project_if_empty
       end
 
       def setup


### PR DESCRIPTION
## Summary
This PR adds support for automatic event replay when a projection table is empty, along with configurable batch processing. It introduces the `project_if_empty` parameter to the `define_projection` macro and implements the corresponding catch-up logic.

## Key Changes
- **New macro parameters**: Added `project_if_empty` (default: false) and `batch_size` (default: 1000) parameters to `define_projection` macro
- **Projection class enhancements**:
  - Added `@@project_if_empty` and `@@projection_batch_size` class variables
  - Added `project_if_empty?` and `projection_batch_size` class methods for accessing configuration
  - Implemented `project_if_empty` instance method that spawns a background fiber to replay events when the table is empty
  - Added `table_empty?` protected method to check if the projection table has any rows
- **Event filtering**: During catch-up, unregistered event handlers are skipped to prevent errors
- **Code organization**: Refactored table creation logic in the macro to use `unless skip` block for better readability

## Implementation Details
- The `project_if_empty` method uses the configured `batch_size` when iterating through events from the event store
- Catch-up processing happens asynchronously in a spawned fiber to avoid blocking
- The `table_empty?` method safely handles empty table names and uses a simple `LIMIT 1` query for efficiency
- All new functionality is covered by comprehensive test cases including edge cases (unregistered handlers, disabled feature, non-empty tables)

https://claude.ai/code/session_01LyRv2SGo7aK2rBaVCYmk1r