### PR TITLE
Change event ID column from SERIAL to BIGSERIAL

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: crystal-es
-version: 0.6.5
+version: 0.6.6
 
 authors:
   - Tristan Holl <mail@tristanholl.com>

--- a/src/adapters/eventstores/postgres.cr
+++ b/src/adapters/eventstores/postgres.cr
@@ -19,7 +19,7 @@ module ES
         m << %( ALTER DEFAULT PRIVILEGES IN SCHEMA "eventstore" GRANT SELECT ON SEQUENCES TO pg_monitor; )
         m << %(
           CREATE TABLE "eventstore"."events" (
-            "id" SERIAL PRIMARY KEY,
+            "id" BIGSERIAL PRIMARY KEY,
             "header" jsonb NOT NULL,
             "body" jsonb NOT NULL
           );
@@ -76,12 +76,12 @@ module ES
         loop do
           rows = if uid = until_event_id
                    @db.query_all(
-                     %(SELECT id, header, body FROM "eventstore"."events" WHERE id > $1 AND id <= (SELECT id FROM "eventstore"."events" WHERE header->>'event_id' = $2) ORDER BY id ASC LIMIT $3),
+                     %(SELECT id::BIGINT, header, body FROM "eventstore"."events" WHERE id > $1 AND id <= (SELECT id FROM "eventstore"."events" WHERE header->>'event_id' = $2) ORDER BY id ASC LIMIT $3),
                      cursor, uid.to_s, batch_size, as: {Int64, JSON::Any, JSON::Any}
                    )
                  else
                    @db.query_all(
-                     %(SELECT id, header, body FROM "eventstore"."events" WHERE id > $1 ORDER BY id ASC LIMIT $2),
+                     %(SELECT id::BIGINT, header, body FROM "eventstore"."events" WHERE id > $1 ORDER BY id ASC LIMIT $2),
                      cursor, batch_size, as: {Int64, JSON::Any, JSON::Any}
                    )
                  end


### PR DESCRIPTION
## Summary
Updated the PostgreSQL event store to use `BIGSERIAL` instead of `SERIAL` for the event ID primary key column, with corresponding type casting in queries.

## Key Changes
- Changed the `"id"` column type from `SERIAL` to `BIGSERIAL` in the `"eventstore"."events"` table creation
- Added explicit `::BIGINT` type casting to the `id` column in both event query operations to ensure proper type handling

## Implementation Details
This change increases the maximum value for event IDs from 2,147,483,647 (32-bit signed integer) to 9,223,372,036,854,775,807 (64-bit signed integer), providing significantly more capacity for event stores that may accumulate large numbers of events over time. The type casting in the SELECT queries ensures the ID is properly returned as `Int64` to the Crystal application layer.

https://claude.ai/code/session_01HAt7ee6wAzJjpbQx6yLxG5