### PR TITLE
Add dynamic consistency boundaries (DCB) based on per-sequence versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,61 @@ end
 
 ---
 
+### Dynamic Consistency Boundaries (DCB)
+
+Classic event sourcing enforces consistency per single aggregate. With **dynamic consistency boundaries** a command can build its decision model from *several* sequences — aggregates and/or **tags** — and atomically append events **conditioned on none of those sequences having advanced** since they were read.
+
+The consistency condition is based purely on per-sequence version numbers (the same optimistic versioning aggregates already use), never on a global sequence. The global `BIGSERIAL id` of the Postgres store remains a projection-replay ordering concern only.
+
+**Sequences.** Every event belongs to one or more sequences, each with its own monotonically increasing version:
+- its primary aggregate (`aggregate_id` / `aggregate_version`), as before
+- any number of extra **tags** via the new `tags` header field (`Hash(String, Int32)`), e.g. `{"course:<uuid>" => 3}`
+
+**Conditional append.** `EventStore#append(events, condition)` atomically appends a batch and raises `ES::Exception::Conflict` if any sequence named in the `ES::AppendCondition` advanced past its expected version — including sequences the batch does not write to (read-only boundary members). In Postgres this is enforced with per-sequence advisory locks and an `event_tags` table with a `UNIQUE(tag, tag_version)` backstop; the in-memory store enforces identical semantics.
+
+**`ES::Boundary`** is the command-layer API: load the sequences the decision depends on (capturing their versions), stage events, and commit atomically.
+
+```crystal
+class Commands::SubscribeStudent < ES::Command
+  def call
+    # Boundary member 1: the student aggregate
+    student = boundary.load(Student.new(@aggregate_id))
+
+    # Boundary member 2: the course tag sequence (the course is not an aggregate)
+    course_tag = "course:#{@course_id}"
+    subscriptions = 0
+    boundary.load(course_tag) do |event|
+      subscriptions += 1 if event.header["event_handle"] == "student_subscribed"
+    end
+
+    raise ES::Exception::InvalidState.new("course full") if subscriptions >= 10
+    raise ES::Exception::InvalidState.new("too many courses") if student.state.course_count >= 5
+
+    boundary.stage(Events::StudentSubscribed.new(
+      aggregate_id: @aggregate_id,
+      aggregate_version: boundary.next_version(student),
+      tags: {course_tag => boundary.next_version(course_tag)},
+      course_id: @course_id,
+      # ...
+    ))
+
+    # Atomic: raises ES::Exception::Conflict if the student OR the course
+    # sequence advanced since it was loaded
+    boundary.commit
+  end
+end
+```
+
+If two such commands race, the loser gets an `ES::Exception::Conflict` even though the two events live under different primary aggregates — the shared course tag serializes them. A sequence can also be enlisted read-only (assert it did not change without writing to it) via `boundary.load(tag) { ... }` or `boundary.track(key, version)` with no staged event carrying that tag.
+
+A complete runnable example lives in [`./examples/course-subscription`](./examples/course-subscription) (`crystal run examples/course-subscription/example.cr` — uses the in-memory store, no infrastructure needed).
+
+> **Note on Postgres pooling:** the conditional append relies on transaction-scoped advisory locks; all statements run on a single connection inside one transaction. When using a pooling proxy, transaction pooling is the minimum requirement — statement pooling breaks the lock semantics.
+
+> **Migration:** `EventStore#setup` is idempotent; re-running it on an existing store creates the `event_tags` table and backfills the primary-aggregate memberships of existing events.
+
+---
+
 ### Projection
 
 `ES::Projection` maintains a read model by consuming events in order. It can be replayed from scratch at any time.

--- a/examples/course-subscription/aggregate.cr
+++ b/examples/course-subscription/aggregate.cr
@@ -1,0 +1,25 @@
+class Student < ES::Aggregate
+  @@type = "student"
+
+  struct State < ES::Aggregate::State
+    property course_count : Int32 = 0
+  end
+
+  getter state : State
+
+  def initialize(
+    aggregate_id : UUID,
+    @event_store : ES::EventStore = ES::Config.event_store,
+    @event_handlers : ES::EventHandlers = ES::Config.event_handlers,
+  )
+    @state = State.new(aggregate_id)
+    @state.set_type(@@type)
+  end
+
+  # Apply 'Events::StudentSubscribed' to the aggregate state
+  def apply(event : Events::StudentSubscribed)
+    @state.increase_version(event.header.aggregate_version)
+
+    @state.course_count += 1
+  end
+end

--- a/examples/course-subscription/commands/subscribe_student.cr
+++ b/examples/course-subscription/commands/subscribe_student.cr
@@ -1,0 +1,43 @@
+class Commands::SubscribeStudent < ES::Command
+  COURSE_CAPACITY   = 2
+  MAX_SUBSCRIPTIONS = 3
+
+  def initialize(
+    @course_id : UUID,
+    aggregate_id : UUID,
+    event_store : ES::EventStore = ES::Config.event_store,
+    event_handlers : ES::EventHandlers = ES::Config.event_handlers,
+  )
+    super(aggregate_id, event_store, event_handlers)
+  end
+
+  def call
+    # The consistency boundary spans two sequences:
+    # - the student aggregate (the primary aggregate of the new event)
+    # - the course tag sequence (the course is not an aggregate here)
+    student = boundary.load(Student.new(@aggregate_id, event_store: @event_store, event_handlers: @event_handlers))
+
+    course_tag = "course:#{@course_id}"
+    subscriptions = 0
+    boundary.load(course_tag) do |event|
+      subscriptions += 1 if event.header["event_handle"] == "student_subscribed"
+    end
+
+    # Business rules across both sequences
+    raise ES::Exception::InvalidState.new("Course '#{@course_id}' is full") if subscriptions >= COURSE_CAPACITY
+    raise ES::Exception::InvalidState.new("Student '#{@aggregate_id}' reached the subscription limit") if student.state.course_count >= MAX_SUBSCRIPTIONS
+
+    boundary.stage(Events::StudentSubscribed.new(
+      actor_id: nil,
+      command_handler: self.class.to_s,
+      aggregate_id: @aggregate_id,
+      aggregate_version: boundary.next_version(student),
+      tags: {course_tag => boundary.next_version(course_tag)},
+      course_id: @course_id
+    ))
+
+    # Atomic conditional append: fails with ES::Exception::Conflict if the student
+    # OR the course sequence advanced since they were loaded
+    boundary.commit
+  end
+end

--- a/examples/course-subscription/events/student_subscribed.cr
+++ b/examples/course-subscription/events/student_subscribed.cr
@@ -1,0 +1,7 @@
+class Events::StudentSubscribed < ES::Event
+  include ::ES::EventDSL
+
+  define_event "student", "student_subscribed" do
+    attribute :course_id, UUID
+  end
+end

--- a/examples/course-subscription/example.cr
+++ b/examples/course-subscription/example.cr
@@ -1,0 +1,67 @@
+require "db"
+
+require "../../src/crystal-es"
+
+require "./events/student_subscribed"
+require "./aggregate"
+require "./commands/subscribe_student"
+
+# Initializing event handlers
+ES::Config.event_handlers = ES::EventHandlers.new
+ES::Config.event_handlers.register(Events::StudentSubscribed)
+
+# The example uses the in-memory store, so it runs without any infrastructure.
+# The same code works against ES::EventStoreAdapters::Postgres.
+ES::Config.event_store = ES::EventStoreAdapters::InMemory.new
+store = ES::Config.event_store
+
+course = UUID.v7
+alice = UUID.v7
+bob = UUID.v7
+carol = UUID.v7
+
+# Alice and Bob take the two seats of the course
+Commands::SubscribeStudent.new(course, alice).call
+Commands::SubscribeStudent.new(course, bob).call
+puts "Seats taken in course '#{course}': #{store.last_version("course:#{course}")}"
+
+# Carol is rejected by the business rule evaluated across the boundary
+begin
+  Commands::SubscribeStudent.new(course, carol).call
+rescue ex : ES::Exception::InvalidState
+  puts "Carol rejected: #{ex.message}"
+end
+
+# Concurrency: two subscriptions race for the last seat of a fresh course.
+# Both boundaries read the course sequence before either of them commits.
+contested_course = UUID.v7
+course_tag = "course:#{contested_course}"
+Commands::SubscribeStudent.new(contested_course, UUID.v7).call
+
+racer_1 = ES::Boundary.new(store)
+racer_1.load(course_tag) { }
+racer_2 = ES::Boundary.new(store)
+racer_2.load(course_tag) { }
+
+racer_1.stage(Events::StudentSubscribed.new(
+  actor_id: nil,
+  command_handler: "race",
+  aggregate_version: 1,
+  tags: {course_tag => racer_1.next_version(course_tag)},
+  course_id: contested_course
+))
+racer_1.commit
+puts "First racer took the last seat"
+
+racer_2.stage(Events::StudentSubscribed.new(
+  actor_id: nil,
+  command_handler: "race",
+  aggregate_version: 1,
+  tags: {course_tag => racer_2.next_version(course_tag)},
+  course_id: contested_course
+))
+begin
+  racer_2.commit
+rescue ES::Exception::Conflict
+  puts "Second racer rejected: the course sequence advanced since it was read"
+end

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: crystal-es
-version: 0.6.6
+version: 0.7.0
 
 authors:
   - Tristan Holl <mail@tristanholl.com>

--- a/spec/adapters/eventstores/eventstore_behavior.cr
+++ b/spec/adapters/eventstores/eventstore_behavior.cr
@@ -1,0 +1,135 @@
+# Shared examples for the conditional append semantics (Dynamic Consistency Boundaries).
+# Include them in an adapter spec via `eventstore_dcb_examples(->{ MyStore.new })` so every
+# event store implementation enforces the same behavior.
+macro eventstore_dcb_examples(factory)
+  it "appends a batch of events atomically" do
+    store = {{ factory }}.call
+    aggregate_id = UUID.v7
+    e1 = DummyEvent.new(aggregate_id: aggregate_id, aggregate_version: 1)
+    e2 = DummyEvent.new(aggregate_id: aggregate_id, aggregate_version: 2)
+
+    store.append([e1, e2] of ES::Event)
+
+    store.fetch_events(aggregate_id).size.should eq(2)
+    store.last_version(aggregate_id.to_s).should eq(2)
+  end
+
+  it "tracks tag sequences independently of the primary aggregate" do
+    store = {{ factory }}.call
+    tag = "course:#{UUID.v7}"
+    e1 = DummyEvent.new(aggregate_version: 1, tags: {tag => 1})
+    e2 = DummyEvent.new(aggregate_version: 1, tags: {tag => 2})
+
+    store.append(e1)
+    store.append(e2)
+
+    store.last_version(tag).should eq(2)
+    store.fetch_events(tag).size.should eq(2)
+  end
+
+  it "fetch_events(tag) returns the tag stream ordered by tag version" do
+    store = {{ factory }}.call
+    tag = "course:#{UUID.v7}"
+    e1 = DummyEvent.new(aggregate_version: 1, tags: {tag => 1})
+    e2 = DummyEvent.new(aggregate_version: 1, tags: {tag => 2})
+    e3 = DummyEvent.new(aggregate_version: 1, tags: {tag => 3})
+
+    store.append(e1)
+    store.append(e2)
+    store.append(e3)
+
+    events = store.fetch_events(tag)
+    events.map { |e| e.header["tags"][tag].as_i }.should eq([1, 2, 3])
+  end
+
+  it "accepts an append when the condition matches the current versions" do
+    store = {{ factory }}.call
+    tag = "course:#{UUID.v7}"
+    store.append(DummyEvent.new(aggregate_version: 1, tags: {tag => 1}))
+
+    event = DummyEvent.new(aggregate_version: 1, tags: {tag => 2})
+    store.append([event] of ES::Event, ES::AppendCondition.new({tag => 1}))
+
+    store.last_version(tag).should eq(2)
+  end
+
+  it "accepts an append conditioned on an empty sequence (expected version 0)" do
+    store = {{ factory }}.call
+    tag = "course:#{UUID.v7}"
+
+    event = DummyEvent.new(aggregate_version: 1, tags: {tag => 1})
+    store.append([event] of ES::Event, ES::AppendCondition.new({tag => 0}))
+
+    store.last_version(tag).should eq(1)
+  end
+
+  it "rejects an append when a condition sequence advanced" do
+    store = {{ factory }}.call
+    tag = "course:#{UUID.v7}"
+    store.append(DummyEvent.new(aggregate_version: 1, tags: {tag => 1}))
+
+    # A competing append advances the tag sequence
+    store.append(DummyEvent.new(aggregate_version: 1, tags: {tag => 2}))
+
+    stale = DummyEvent.new(aggregate_version: 1, tags: {tag => 2})
+    expect_raises(ES::Exception::Conflict) do
+      store.append([stale] of ES::Event, ES::AppendCondition.new({tag => 1}))
+    end
+  end
+
+  it "rejects an append when a read-only condition member advanced" do
+    store = {{ factory }}.call
+    tag = "course:#{UUID.v7}"
+    store.append(DummyEvent.new(aggregate_version: 1, tags: {tag => 1}))
+
+    # The event does not write to the tag sequence, the condition only asserts it
+    event = DummyEvent.new(aggregate_version: 1)
+    expect_raises(ES::Exception::Conflict) do
+      store.append([event] of ES::Event, ES::AppendCondition.new({tag => 0}))
+    end
+  end
+
+  it "rejects non-contiguous versions within a written sequence" do
+    store = {{ factory }}.call
+    aggregate_id = UUID.v7
+    store.append(DummyEvent.new(aggregate_id: aggregate_id, aggregate_version: 1))
+
+    gap = DummyEvent.new(aggregate_id: aggregate_id, aggregate_version: 3)
+    expect_raises(ES::Exception::Conflict) do
+      store.append(gap)
+    end
+  end
+
+  it "rejects a duplicate version within a written sequence" do
+    store = {{ factory }}.call
+    aggregate_id = UUID.v7
+    store.append(DummyEvent.new(aggregate_id: aggregate_id, aggregate_version: 1))
+
+    duplicate = DummyEvent.new(aggregate_id: aggregate_id, aggregate_version: 1)
+    expect_raises(ES::Exception::Conflict) do
+      store.append(duplicate)
+    end
+  end
+
+  it "rejects the whole batch if any event conflicts" do
+    store = {{ factory }}.call
+    aggregate_id = UUID.v7
+    tag = "course:#{UUID.v7}"
+    store.append(DummyEvent.new(aggregate_version: 1, tags: {tag => 1}))
+
+    e1 = DummyEvent.new(aggregate_id: aggregate_id, aggregate_version: 1)
+    e2 = DummyEvent.new(aggregate_version: 1, tags: {tag => 1}) # duplicate tag version
+
+    expect_raises(ES::Exception::Conflict) do
+      store.append([e1, e2] of ES::Event)
+    end
+
+    store.fetch_events(aggregate_id).should be_empty
+    store.last_version(aggregate_id.to_s).should eq(0)
+  end
+
+  it "last_version returns 0 for unknown sequences" do
+    store = {{ factory }}.call
+    store.last_version("unknown:sequence").should eq(0)
+  end
+end

--- a/spec/adapters/eventstores/eventstore_spec.cr
+++ b/spec/adapters/eventstores/eventstore_spec.cr
@@ -5,15 +5,23 @@ class MyEventStore < ES::EventStore
     # Noop
   end
 
-  def append(event : ES::Event)
+  def append(events : Array(ES::Event), condition : ES::AppendCondition = ES::AppendCondition.none)
   end
 
   def fetch_events(aggregate_id : UUID) : Array(ES::EventStore::Event)
     [] of ES::EventStore::Event
   end
 
+  def fetch_events(tag : String) : Array(ES::EventStore::Event)
+    [] of ES::EventStore::Event
+  end
+
   def fetch_event(event_id : UUID) : ES::EventStore::Event
     nil
+  end
+
+  def last_version(sequence_key : String) : Int32
+    0
   end
 
   def each_event(until_event_id : UUID? = nil, batch_size : Int64 = 1000, &block : ES::EventStore::Event ->)

--- a/spec/adapters/eventstores/in_memory_spec.cr
+++ b/spec/adapters/eventstores/in_memory_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 require "./eventstore_behavior"
 
 describe ES::EventStoreAdapters::InMemory do
-  eventstore_dcb_examples(->{ ES::EventStoreAdapters::InMemory.new })
+  eventstore_dcb_examples(-> { ES::EventStoreAdapters::InMemory.new })
   it "does not forward events to the queue when the batch conflicts" do
     queue = ES::QueueAdapters::InMemory.new("default")
     store = ES::EventStoreAdapters::InMemory.new(queue)

--- a/spec/adapters/eventstores/in_memory_spec.cr
+++ b/spec/adapters/eventstores/in_memory_spec.cr
@@ -1,6 +1,24 @@
 require "../../spec_helper"
+require "./eventstore_behavior"
 
 describe ES::EventStoreAdapters::InMemory do
+  eventstore_dcb_examples(->{ ES::EventStoreAdapters::InMemory.new })
+  it "does not forward events to the queue when the batch conflicts" do
+    queue = ES::QueueAdapters::InMemory.new("default")
+    store = ES::EventStoreAdapters::InMemory.new(queue)
+    aggregate_id = UUID.v7
+
+    store.append(DummyEvent.new(aggregate_id: aggregate_id, aggregate_version: 1))
+    queue.cursor.should eq(1)
+
+    duplicate = DummyEvent.new(aggregate_id: aggregate_id, aggregate_version: 1)
+    expect_raises(ES::Exception::Conflict) do
+      store.append([DummyEvent.new, duplicate] of ES::Event)
+    end
+
+    queue.cursor.should eq(1)
+  end
+
   it "each_event yields all events in insertion order" do
     store = ES::EventStoreAdapters::InMemory.new
     e1 = DummyEvent.new

--- a/spec/adapters/eventstores/postgres_spec.cr
+++ b/spec/adapters/eventstores/postgres_spec.cr
@@ -6,4 +6,31 @@ describe ES::EventStoreAdapters::Postgres do
 
   pending "last_event_id returns the most recently appended event's id", tags: "db" do
   end
+
+  pending "setup creates the event_tags table and backfills primary-aggregate memberships", tags: "db" do
+  end
+
+  pending "append inserts one event_tags row per sequence membership", tags: "db" do
+  end
+
+  pending "append raises a conflict when a condition sequence advanced", tags: "db" do
+  end
+
+  pending "append raises a conflict when a read-only condition member advanced concurrently", tags: "db" do
+  end
+
+  pending "append rejects non-contiguous versions within a written sequence", tags: "db" do
+  end
+
+  pending "append rolls back the whole batch on conflict", tags: "db" do
+  end
+
+  pending "append translates unique violations (SQLSTATE 23505) into a conflict", tags: "db" do
+  end
+
+  pending "fetch_events(tag) returns the tag stream ordered by tag version", tags: "db" do
+  end
+
+  pending "last_version returns 0 for unknown sequences", tags: "db" do
+  end
 end

--- a/spec/components/boundary_spec.cr
+++ b/spec/components/boundary_spec.cr
@@ -1,0 +1,165 @@
+require "../spec_helper"
+
+class BoundaryTestEvent < ES::Event
+  include ::ES::EventDSL
+
+  define_event "BoundaryTestAggregate", "boundary.test.event" do
+    attribute :amount, Int32, 0
+  end
+end
+
+class BoundaryTestAggregate < ES::Aggregate
+  @@type = "BoundaryTestAggregate"
+
+  struct State < ES::Aggregate::State
+    property total : Int32 = 0
+  end
+
+  getter state : State
+
+  def initialize(
+    aggregate_id : UUID,
+    @event_store : ES::EventStore,
+    @event_handlers : ES::EventHandlers,
+  )
+    @state = State.new(aggregate_id)
+    @state.set_type(@@type)
+  end
+
+  def apply(event : BoundaryTestEvent)
+    @state.increase_version(event.header.aggregate_version)
+
+    @state.total += event.body.as(BoundaryTestEvent::Body).amount
+  end
+end
+
+private def boundary_setup
+  store = ES::EventStoreAdapters::InMemory.new
+  handlers = ES::EventHandlers.new
+  handlers.register(BoundaryTestEvent)
+
+  {store, handlers}
+end
+
+describe ES::Boundary do
+  it "loads an aggregate and captures its version in the condition" do
+    store, handlers = boundary_setup
+    aggregate_id = UUID.v7
+    store.append(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_id: aggregate_id, aggregate_version: 1, amount: 5))
+
+    boundary = ES::Boundary.new(store)
+    aggregate = boundary.load(BoundaryTestAggregate.new(aggregate_id, store, handlers))
+
+    aggregate.state.total.should eq(5)
+    boundary.next_version(aggregate).should eq(2)
+  end
+
+  it "loads an aggregate without events at version 0" do
+    store, handlers = boundary_setup
+
+    boundary = ES::Boundary.new(store)
+    aggregate = boundary.load(BoundaryTestAggregate.new(UUID.v7, store, handlers))
+
+    aggregate.state.version.should eq(0)
+    boundary.next_version(aggregate).should eq(1)
+  end
+
+  it "folds a tag stream and captures the tag version" do
+    store, _ = boundary_setup
+    tag = "course:#{UUID.v7}"
+    store.append(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_version: 1, tags: {tag => 1}))
+    store.append(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_version: 1, tags: {tag => 2}))
+
+    boundary = ES::Boundary.new(store)
+    count = 0
+    boundary.load(tag) { |_event| count += 1 }
+
+    count.should eq(2)
+    boundary.next_version(tag).should eq(3)
+  end
+
+  it "commits staged events atomically" do
+    store, handlers = boundary_setup
+    aggregate_id = UUID.v7
+    tag = "course:#{UUID.v7}"
+
+    boundary = ES::Boundary.new(store)
+    aggregate = boundary.load(BoundaryTestAggregate.new(aggregate_id, store, handlers))
+    boundary.load(tag) { }
+
+    boundary.stage(BoundaryTestEvent.new(
+      actor_id: nil,
+      command_handler: "test",
+      aggregate_id: aggregate_id,
+      aggregate_version: boundary.next_version(aggregate),
+      tags: {tag => boundary.next_version(tag)},
+      amount: 5
+    ))
+    boundary.commit
+
+    store.last_version(aggregate_id.to_s).should eq(1)
+    store.last_version(tag).should eq(1)
+  end
+
+  it "accounts for staged events when computing the next version" do
+    store, handlers = boundary_setup
+    aggregate_id = UUID.v7
+
+    boundary = ES::Boundary.new(store)
+    aggregate = boundary.load(BoundaryTestAggregate.new(aggregate_id, store, handlers))
+
+    boundary.next_version(aggregate).should eq(1)
+    boundary.stage(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_id: aggregate_id, aggregate_version: 1))
+    boundary.next_version(aggregate).should eq(2)
+    boundary.stage(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_id: aggregate_id, aggregate_version: 2))
+    boundary.next_version(aggregate).should eq(3)
+  end
+
+  it "raises a conflict when a loaded sequence advanced between load and commit" do
+    store, handlers = boundary_setup
+    tag = "course:#{UUID.v7}"
+
+    boundary = ES::Boundary.new(store)
+    boundary.load(tag) { }
+
+    # A competing writer advances the tag sequence after the boundary was built
+    store.append(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_version: 1, tags: {tag => 1}))
+
+    boundary.stage(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_version: 1))
+    expect_raises(ES::Exception::Conflict) do
+      boundary.commit
+    end
+  end
+
+  it "raises a conflict when a read-only tracked sequence advanced" do
+    store, handlers = boundary_setup
+    tag = "course:#{UUID.v7}"
+    store.append(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_version: 1, tags: {tag => 1}))
+
+    boundary = ES::Boundary.new(store)
+    boundary.track(tag, 1)
+
+    store.append(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_version: 1, tags: {tag => 2}))
+
+    boundary.stage(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_version: 1))
+    expect_raises(ES::Exception::Conflict) do
+      boundary.commit
+    end
+  end
+
+  it "can be reused after a successful commit" do
+    store, handlers = boundary_setup
+    aggregate_id = UUID.v7
+
+    boundary = ES::Boundary.new(store)
+    aggregate = boundary.load(BoundaryTestAggregate.new(aggregate_id, store, handlers))
+
+    boundary.stage(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_id: aggregate_id, aggregate_version: boundary.next_version(aggregate)))
+    boundary.commit
+
+    boundary.stage(BoundaryTestEvent.new(actor_id: nil, command_handler: "test", aggregate_id: aggregate_id, aggregate_version: boundary.next_version(aggregate_id.to_s)))
+    boundary.commit
+
+    store.last_version(aggregate_id.to_s).should eq(2)
+  end
+end

--- a/spec/components/event_spec.cr
+++ b/spec/components/event_spec.cr
@@ -41,6 +41,63 @@ describe ES::Event do
     b.test.should eq("test")
   end
 
+  it "creates the event with tags" do
+    e = TestDummyEvent.new(
+      actor_id: nil,
+      aggregate_id: UUID.new("7efe288b-8d33-4359-b799-fd71b32a648e"),
+      command_handler: "Test",
+      test: "test",
+      tags: {"course:1" => 3}
+    )
+
+    e.header.tags.should eq({"course:1" => 3})
+  end
+
+  it "defaults tags to an empty hash" do
+    e = TestDummyEvent.new(
+      actor_id: nil,
+      command_handler: "Test",
+      test: "test"
+    )
+
+    e.header.tags.should eq({} of String => Int32)
+  end
+
+  it "returns all sequence memberships including the primary aggregate" do
+    e = TestDummyEvent.new(
+      actor_id: nil,
+      aggregate_id: UUID.new("7efe288b-8d33-4359-b799-fd71b32a648e"),
+      aggregate_version: 2,
+      command_handler: "Test",
+      test: "test",
+      tags: {"course:1" => 3}
+    )
+
+    e.memberships.should eq({
+      "7efe288b-8d33-4359-b799-fd71b32a648e" => 2,
+      "course:1"                             => 3,
+    })
+  end
+
+  it "header round-trips tags through json" do
+    e = TestDummyEvent.new(
+      actor_id: nil,
+      command_handler: "Test",
+      test: "test",
+      tags: {"course:1" => 3}
+    )
+
+    h = ES::Event::Header.from_json(e.header.to_json)
+    h.tags.should eq({"course:1" => 3})
+  end
+
+  it "header without tags parses to an empty hash" do
+    json = %({"aggregate_id":"7efe288b-8d33-4359-b799-fd71b32a648e","aggregate_type":"Test","aggregate_version":1,"command_handler":"Test","command_handler_version":"unknown","created_at":"2026-01-01T00:00:00Z","event_handle":"test.dummy.event","event_id":"0197b7a2-91cd-7b21-b7be-cfdaf40ae199","event_version":"1.0.0"})
+
+    h = ES::Event::Header.from_json(json)
+    h.tags.should eq({} of String => Int32)
+  end
+
   it "body can be serialized to json" do
     e = TestDummyEvent.new(
       actor_id: UUID.new("43ab4533-d06c-4086-bce9-83a7642fb666"),

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -36,14 +36,19 @@ class DummyEvent < ES::Event
     @body = Body.from_json(body.to_json)
   end
 
-  def initialize
+  def initialize(
+    aggregate_id : UUID = UUID.v7,
+    aggregate_version : Int32 = 1,
+    tags : Hash(String, Int32) = {} of String => Int32,
+  )
     @header = Header.new(
       actor_id: UUID.v7,
-      aggregate_id: UUID.v7,
+      aggregate_id: aggregate_id,
       aggregate_type: "Test",
-      aggregate_version: 1,
+      aggregate_version: aggregate_version,
       command_handler: "test",
-      event_handle: @@handle
+      event_handle: @@handle,
+      tags: tags
     )
     @body = Body.new("comment")
   end

--- a/src/adapters/eventstores/eventstore.cr
+++ b/src/adapters/eventstores/eventstore.cr
@@ -1,11 +1,24 @@
 module ES
   abstract class EventStore
-    abstract def append(event : ES::Event)
+    # Atomically appends a batch of events, guarded by an append condition (the DCB primitive).
+    # Raises ES::Exception::Conflict if any sequence in the condition advanced past its
+    # expected version, or if the staged versions are not contiguous with the stored ones.
+    abstract def append(events : Array(ES::Event), condition : ES::AppendCondition = ES::AppendCondition.none)
+
     abstract def fetch_events(aggregate_id : UUID) : Array(ES::EventStore::Event)
+    abstract def fetch_events(tag : String) : Array(ES::EventStore::Event)
     abstract def fetch_event(event_id : UUID) : ES::EventStore::Event
     abstract def setup
     abstract def each_event(until_event_id : UUID? = nil, batch_size : Int64 = 1000, &block : ES::EventStore::Event ->)
     abstract def last_event_id : UUID?
+
+    # Returns the last version of the given sequence (aggregate_id or tag), 0 if empty
+    abstract def last_version(sequence_key : String) : Int32
+
+    # Appends a single event, optionally guarded by an append condition
+    def append(event : ES::Event, condition : ES::AppendCondition = ES::AppendCondition.none)
+      append([event], condition)
+    end
 
     struct Event
       getter header : JSON::Any

--- a/src/adapters/eventstores/in_memory.cr
+++ b/src/adapters/eventstores/in_memory.cr
@@ -2,6 +2,8 @@ module ES
   module EventStoreAdapters
     class InMemory < ES::EventStore
       @events : Hash(UUID, ES::EventStore::Event) = Hash(UUID, ES::EventStore::Event).new
+      @tag_versions : Hash(String, Int32) = Hash(String, Int32).new
+      @mutex : Mutex = Mutex.new
 
       # Initialize with an optional queue adapter
       def initialize(@queue : ES::QueueAdapters::InMemory? = nil)
@@ -12,12 +14,33 @@ module ES
         # Noop
       end
 
-      # Appends an event to the event stream
-      def append(event : ES::Event)
-        @events[event.header.event_id] = ES::EventStore::Event.new(JSON.parse(event.header.to_json), JSON.parse(event.body.to_json))
+      # Atomically appends a batch of events, guarded by an append condition
+      def append(events : Array(ES::Event), condition : ES::AppendCondition = ES::AppendCondition.none)
+        @mutex.synchronize do
+          staged = @tag_versions.dup
 
-        q = @queue
-        q.append(event) unless q.nil?
+          condition.expected.each do |key, expected|
+            actual = staged.fetch(key, 0)
+            raise ES::Exception::Conflict.new("Sequence '#{key}' is at version '#{actual}', expected version '#{expected}'") if actual != expected
+          end
+
+          events.each do |event|
+            event.memberships.each do |key, version|
+              next_version = staged.fetch(key, 0) + 1
+              raise ES::Exception::Conflict.new("Non-contiguous version for sequence '#{key}': provided version '#{version}', expected version '#{next_version}'") if version != next_version
+              staged[key] = version
+            end
+          end
+
+          # All checks passed, commit the batch
+          @tag_versions = staged
+          events.each do |event|
+            @events[event.header.event_id] = ES::EventStore::Event.new(JSON.parse(event.header.to_json), JSON.parse(event.body.to_json))
+
+            q = @queue
+            q.append(event) unless q.nil?
+          end
+        end
       end
 
       # Returns a single event for a given id
@@ -45,6 +68,11 @@ module ES
         @events.last_key?
       end
 
+      # Returns the last version of the given sequence (aggregate_id or tag), 0 if empty
+      def last_version(sequence_key : String) : Int32
+        @tag_versions.fetch(sequence_key, 0)
+      end
+
       # Returns the stream of events for a given aggregate
       def fetch_events(aggregate_id : UUID) : Array(ES::EventStore::Event)
         event_array = Array(ES::EventStore::Event).new
@@ -61,6 +89,28 @@ module ES
         end
 
         event_array
+      end
+
+      # Returns the stream of events for a given sequence key (aggregate_id or tag), ordered by that sequence's version
+      def fetch_events(tag : String) : Array(ES::EventStore::Event)
+        members = Array({Int32, ES::EventStore::Event}).new
+
+        @events.each_value do |event|
+          version = sequence_version(event.header, tag)
+          members << {version, ES::EventStore::Event.new(event.header, event.body)} unless version.nil?
+        end
+
+        members.sort_by! { |version, _| version }
+        members.map { |_, event| event }
+      end
+
+      # Returns the version of the event within the given sequence, or nil if it is not a member
+      private def sequence_version(header : JSON::Any, tag : String) : Int32?
+        return header["aggregate_version"].as_i if header["aggregate_id"].to_s == tag
+
+        if tags = header["tags"]?
+          tags[tag]?.try(&.as_i)
+        end
       end
     end
   end

--- a/src/adapters/eventstores/postgres.cr
+++ b/src/adapters/eventstores/postgres.cr
@@ -7,9 +7,6 @@ module ES
 
       # Initializes the database with the necessary schema, table and permissions for the eventstore
       def setup
-        skip = @db.query_one %(SELECT EXISTS (SELECT FROM pg_tables WHERE  schemaname = 'eventstore' AND tablename  = 'events');), as: Bool
-        return true if skip
-
         m = Array(String).new
         m << %( CREATE SCHEMA IF NOT EXISTS "eventstore"; )
         m << %( GRANT USAGE ON SCHEMA "eventstore" TO pg_monitor; )
@@ -18,14 +15,36 @@ module ES
         m << %( ALTER DEFAULT PRIVILEGES IN SCHEMA "eventstore" GRANT SELECT ON TABLES TO pg_monitor; )
         m << %( ALTER DEFAULT PRIVILEGES IN SCHEMA "eventstore" GRANT SELECT ON SEQUENCES TO pg_monitor; )
         m << %(
-          CREATE TABLE "eventstore"."events" (
+          CREATE TABLE IF NOT EXISTS "eventstore"."events" (
             "id" BIGSERIAL PRIMARY KEY,
             "header" jsonb NOT NULL,
             "body" jsonb NOT NULL
           );
         )
 
-        m << %(CREATE UNIQUE INDEX aggregate_id_version_idx ON "eventstore"."events"((header->>'aggregate_id'), (header->>'aggregate_version'));)
+        m << %(CREATE UNIQUE INDEX IF NOT EXISTS aggregate_id_version_idx ON "eventstore"."events"((header->>'aggregate_id'), (header->>'aggregate_version'));)
+
+        # Sequence memberships of every event: the primary aggregate plus any tags.
+        # The primary key enforces per-sequence version uniqueness as a backstop for
+        # the conditional append.
+        m << %(
+          CREATE TABLE IF NOT EXISTS "eventstore"."event_tags" (
+            "tag"         TEXT   NOT NULL,
+            "tag_version" INT    NOT NULL,
+            "event_id"    BIGINT NOT NULL REFERENCES "eventstore"."events"("id") ON DELETE CASCADE,
+            PRIMARY KEY ("tag", "tag_version")
+          );
+        )
+        m << %(CREATE INDEX IF NOT EXISTS event_tags_event_id_idx ON "eventstore"."event_tags"("event_id");)
+
+        # Backfill primary-aggregate memberships for events appended before the
+        # event_tags table existed (idempotent)
+        m << %(
+          INSERT INTO "eventstore"."event_tags" (tag, tag_version, event_id)
+          SELECT e.header->>'aggregate_id', (e.header->>'aggregate_version')::INT, e.id
+          FROM "eventstore"."events" e
+          ON CONFLICT DO NOTHING;
+        )
 
         m << %(
           CREATE OR REPLACE VIEW "eventstore"."eventstore_flattened"
@@ -36,6 +55,7 @@ module ES
             e.header ->> 'event_handle' AS "event_handle",
             e.header ->> 'aggregate_version' AS "aggregate_version",
             e.header ->> 'aggregate_type' AS "aggregate_type",
+            e.header -> 'tags' AS "tags",
             e.header,
             e.body
           FROM
@@ -49,9 +69,57 @@ module ES
         m.each { |s| @db.exec s }
       end
 
-      # Appends an event to the event stream
-      def append(event : ES::Event)
-        @db.exec %(INSERT INTO "eventstore"."events" (header, body) VALUES ($1, $2)), event.header.to_json, event.body.to_json
+      # Atomically appends a batch of events, guarded by an append condition.
+      #
+      # All sequence keys involved (condition members and written sequences) are
+      # serialized via transaction-scoped advisory locks, acquired in sorted order to
+      # avoid deadlocks. Under those locks the current version of every sequence is
+      # validated against the condition and the staged versions, so read-only boundary
+      # members are race-free without SERIALIZABLE isolation.
+      def append(events : Array(ES::Event), condition : ES::AppendCondition = ES::AppendCondition.none)
+        written = Hash(String, Array(Int32)).new { |hash, key| hash[key] = Array(Int32).new }
+        events.each do |event|
+          event.memberships.each { |key, version| written[key] << version }
+        end
+
+        keys = (condition.expected.keys + written.keys).uniq.sort
+
+        @db.transaction do |tx|
+          cnn = tx.connection
+
+          keys.each do |key|
+            cnn.exec %(SELECT pg_advisory_xact_lock(hashtextextended($1, 0))), key
+          end
+
+          keys.each do |key|
+            actual = cnn.query_one %(SELECT COALESCE(MAX(tag_version), 0)::INT FROM "eventstore"."event_tags" WHERE tag = $1), key, as: Int32
+
+            if expected = condition.expected[key]?
+              raise ES::Exception::Conflict.new("Sequence '#{key}' is at version '#{actual}', expected version '#{expected}'") if actual != expected
+            end
+
+            if staged = written[key]?
+              staged.sort!
+              expected_range = ((actual + 1)..(actual + staged.size)).to_a
+              raise ES::Exception::Conflict.new("Non-contiguous versions for sequence '#{key}': provided versions '#{staged}', current version '#{actual}'") if staged != expected_range
+            end
+          end
+
+          events.each do |event|
+            row_id = cnn.query_one %(INSERT INTO "eventstore"."events" (header, body) VALUES ($1, $2) RETURNING id), event.header.to_json, event.body.to_json, as: Int64
+
+            event.memberships.each do |tag, version|
+              cnn.exec %(INSERT INTO "eventstore"."event_tags" (tag, tag_version, event_id) VALUES ($1, $2, $3)), tag, version, row_id
+            end
+          end
+        end
+      rescue ex : ES::Exception::Error
+        raise ex
+      rescue ex
+        # Backstop: translate unique violations (SQLSTATE 23505) raised by the events
+        # or event_tags constraints into a Conflict
+        raise ES::Exception::Conflict.new("Concurrent append detected: #{ex.message}") if ex.message.try(&.matches?(/23505|duplicate key/))
+        raise ex
       end
 
       # Returns a single event for a given id
@@ -106,6 +174,11 @@ module ES
         result ? UUID.new(result) : nil
       end
 
+      # Returns the last version of the given sequence (aggregate_id or tag), 0 if empty
+      def last_version(sequence_key : String) : Int32
+        @db.query_one %(SELECT COALESCE(MAX(tag_version), 0)::INT FROM "eventstore"."event_tags" WHERE tag = $1), sequence_key, as: Int32
+      end
+
       # Returns the stream of events for a given aggregate
       def fetch_events(aggregate_id : UUID) : Array(ES::EventStore::Event)
         event_array = Array(ES::EventStore::Event).new
@@ -113,6 +186,21 @@ module ES
         prepared_statement = @db.build(%(SELECT header, body FROM "eventstore"."events" WHERE header->>'aggregate_id'=$1 ORDER BY (header->>'aggregate_version')::INT ASC))
 
         prepared_statement.query(aggregate_id) do |result|
+          result.each do
+            event_array << ES::EventStore::Event.new(result.read(JSON::Any), result.read(JSON::Any))
+          end
+        end
+
+        event_array
+      end
+
+      # Returns the stream of events for a given sequence key (aggregate_id or tag), ordered by that sequence's version
+      def fetch_events(tag : String) : Array(ES::EventStore::Event)
+        event_array = Array(ES::EventStore::Event).new
+
+        prepared_statement = @db.build(%(SELECT e.header, e.body FROM "eventstore"."events" e JOIN "eventstore"."event_tags" t ON t.event_id = e.id WHERE t.tag = $1 ORDER BY t.tag_version ASC))
+
+        prepared_statement.query(tag) do |result|
           result.each do
             event_array << ES::EventStore::Event.new(result.read(JSON::Any), result.read(JSON::Any))
           end

--- a/src/components/append_condition.cr
+++ b/src/components/append_condition.cr
@@ -1,0 +1,24 @@
+module ES
+  # Consistency condition for an atomic append (Dynamic Consistency Boundary).
+  #
+  # Maps sequence keys to the last version seen when the decision model was built.
+  # A sequence key is either an aggregate_id (as string) or a tag. An expected
+  # version of 0 asserts that the sequence is still empty. Condition keys may
+  # reference sequences the append does not write to (read-only boundary members).
+  struct AppendCondition
+    getter expected : Hash(String, Int32)
+
+    def initialize(@expected : Hash(String, Int32) = {} of String => Int32)
+    end
+
+    # Returns an unconditional append condition
+    def self.none
+      new
+    end
+
+    # Returns true if no expectations are set
+    def empty? : Bool
+      @expected.empty?
+    end
+  end
+end

--- a/src/components/boundary.cr
+++ b/src/components/boundary.cr
@@ -1,0 +1,93 @@
+module ES
+  # Builds a dynamic consistency boundary for a command.
+  #
+  # A boundary collects the sequences (aggregates and/or tags) a decision is based on,
+  # captures the version at which each sequence was read, and stages new events for an
+  # atomic conditional append. On commit, the event store rejects the batch with
+  # ES::Exception::Conflict if any member sequence advanced since it was loaded.
+  class Boundary
+    getter pending : Array(ES::Event)
+
+    def initialize(@event_store : ES::EventStore = ES::Config.event_store)
+      @expected = Hash(String, Int32).new
+      @staged_counts = Hash(String, Int32).new
+      @pending = Array(ES::Event).new
+    end
+
+    # Hydrates an aggregate into the boundary; aggregates without events join at version 0
+    def load(aggregate : ES::Aggregate) : ES::Aggregate
+      begin
+        aggregate.hydrate
+      rescue ES::Exception::NotFound
+      end
+
+      track(aggregate.state.aggregate_id.to_s, aggregate.state.version)
+      aggregate
+    end
+
+    # Folds the event stream of a sequence key (aggregate_id or tag) into caller-supplied
+    # state and enlists the sequence at the version that was read
+    def load(tag : String, & : ES::EventStore::Event ->)
+      last = 0
+
+      @event_store.fetch_events(tag).each do |event|
+        yield event
+        version = sequence_version(event.header, tag)
+        last = version unless version.nil?
+      end
+
+      track(tag, last)
+    end
+
+    # Enlists a sequence at a known version without folding its events (read-only assert)
+    def track(key : String, version : Int32)
+      @expected[key] = version
+    end
+
+    # Returns the version to stamp on the next event for the given sequence key,
+    # accounting for events already staged in this boundary
+    def next_version(key : String) : Int32
+      base = @expected[key]? || @event_store.last_version(key)
+      base + @staged_counts.fetch(key, 0) + 1
+    end
+
+    # Returns the next version for the given aggregate's sequence
+    def next_version(aggregate : ES::Aggregate) : Int32
+      next_version(aggregate.state.aggregate_id.to_s)
+    end
+
+    # Stages an event for the atomic commit
+    def stage(event : ES::Event)
+      event.memberships.each_key do |key|
+        @staged_counts[key] = @staged_counts.fetch(key, 0) + 1
+      end
+
+      @pending << event
+    end
+
+    # Atomically appends all staged events, conditioned on every loaded sequence still
+    # being at the version it was read at. Raises ES::Exception::Conflict otherwise.
+    def commit
+      @event_store.append(@pending, ES::AppendCondition.new(@expected))
+
+      # Advance the boundary to the committed versions so it can be reused
+      @pending.each do |event|
+        event.memberships.each do |key, version|
+          @expected[key] = version if @expected.fetch(key, 0) < version
+        end
+      end
+
+      @pending.clear
+      @staged_counts.clear
+    end
+
+    # Returns the version of the event within the given sequence, or nil if it is not a member
+    private def sequence_version(header : JSON::Any, tag : String) : Int32?
+      return header["aggregate_version"].as_i if header["aggregate_id"].to_s == tag
+
+      if tags = header["tags"]?
+        tags[tag]?.try(&.as_i)
+      end
+    end
+  end
+end

--- a/src/components/command.cr
+++ b/src/components/command.cr
@@ -4,6 +4,7 @@ module ES
 
     @aggregate_id : UUID
     @trigger_event : ES::Event?
+    @boundary : ES::Boundary?
 
     # Initialize with a random aggregate ID
     def initialize(
@@ -19,6 +20,11 @@ module ES
       @event_store : ES::EventStore = ES::Config.event_store,
       @event_handlers : ES::EventHandlers = ES::Config.event_handlers,
     )
+    end
+
+    # Returns the memoized consistency boundary for this command
+    def boundary : ES::Boundary
+      @boundary ||= ES::Boundary.new(@event_store)
     end
 
     # Execute command with trigger event parameter

--- a/src/components/event.cr
+++ b/src/components/event.cr
@@ -17,6 +17,7 @@ module ES
       getter event_handle : String = "undefined"
       getter event_id : UUID = UUID.v7
       getter event_version : String = "1.0.0"
+      getter tags : Hash(String, Int32) = {} of String => Int32
 
       # Default constructor
       def initialize; end
@@ -31,6 +32,7 @@ module ES
         @aggregate_type = "undefined",
         @command_handler = "undefined",
         @command_handler_version = ES::Config.version,
+        @tags = {} of String => Int32,
       )
       end
     end
@@ -53,6 +55,11 @@ module ES
     # Returns the event handle
     def self.handle
       @@handle
+    end
+
+    # Returns all sequence memberships of the event: the primary aggregate plus any tags
+    def memberships : Hash(String, Int32)
+      {header.aggregate_id.to_s => header.aggregate_version}.merge(header.tags)
     end
 
     def initialize

--- a/src/components/event_dsl.cr
+++ b/src/components/event_dsl.cr
@@ -58,6 +58,7 @@ module ES
         comment = "",
         aggregate_id = UUID.v7,
         aggregate_version : Int32 = 1,
+        tags : Hash(String, Int32) = {} of String => Int32,
       )
         @header = Header.new(
           actor_id: actor_id,
@@ -65,7 +66,8 @@ module ES
           aggregate_type: @@type,
           aggregate_version: aggregate_version,
           command_handler: command_handler,
-          event_handle: @@handle
+          event_handle: @@handle,
+          tags: tags
         )
         @body = Body.new(
           comment: comment,

--- a/src/crystal-es.cr
+++ b/src/crystal-es.cr
@@ -1,5 +1,5 @@
 require "./load"
 
 module ES
-  VERSION = "0.3.1"
+  VERSION = "0.7.0"
 end

--- a/src/load.cr
+++ b/src/load.cr
@@ -20,6 +20,8 @@ require "./exceptions/not_implemented.cr"
 
 # Event sourcing components
 require "./components/aggregate.cr"
+require "./components/append_condition.cr"
+require "./components/boundary.cr"
 require "./components/command.cr"
 require "./components/event_bus.cr"
 require "./components/event_dsl.cr"


### PR DESCRIPTION
Introduce DCB support so a command can build its decision model from
several sequences (aggregates and/or tags) and atomically append events
conditioned on none of those sequences having advanced since they were
read. The consistency condition is based purely on per-sequence version
numbers - the aggregate-style optimistic versioning already in use -
never on the global BIGSERIAL id, which remains a projection-replay
ordering concern only.

- Events keep their primary aggregate_id/aggregate_version and can
  additionally join other sequences via a new tags header field
  (Hash(String, Int32)); Event#memberships unifies both
- New ES::AppendCondition (sequence key -> expected version) and
  atomic EventStore#append(events, condition); conflicts raise
  ES::Exception::Conflict, including for read-only boundary members
- Postgres: new eventstore.event_tags table with UNIQUE(tag,
  tag_version) backstop, idempotent setup with backfill of existing
  events, conditional append serialized via sorted transaction-scoped
  advisory locks (no SERIALIZABLE retries), fetch_events(tag),
  last_version, and 23505 -> Conflict translation
- InMemory: same conditional append semantics with validate-then-commit
  under a mutex, making DCB fully testable without a database
- New ES::Boundary command-layer API (load/track/next_version/stage/
  commit) plus a memoized Command#boundary helper
- Shared DCB behavior examples run against the in-memory adapter,
  new boundary/event specs, and pending stubs for the Postgres specs
- New examples/course-subscription app demonstrating a cross-entity
  invariant and a conflict on a raced append; README section; version
  bump to 0.7.0

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017WKto8rACBp53T9fCaB5oU